### PR TITLE
chore: raise prometheus dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/heat1q/prometheus-macros"
 keywords = ["prometheus", "metrics"]
 license = "Apache-2.0"
 readme = "README.md"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-prometheus = { version = "0.13",  default-feature = false}
+prometheus = { version = "0.14",  default-feature = false}


### PR DESCRIPTION
prometheus 0.13.0 is affected by [CVE-2019-15544](https://www.cve.org/CVERecord?id=CVE-2019-15544)